### PR TITLE
Improved readTempF function for LSM6DSM

### DIFF
--- a/libraries/00_LIBS/src/lsm6dsm.cpp
+++ b/libraries/00_LIBS/src/lsm6dsm.cpp
@@ -549,7 +549,7 @@ float LSM6DSM::calcAccel(int16_t input)
 /**
   * @brief  Read gyro Z-axis raw data   
   * @param  None
-  * @retval X-axis raw data
+  * @retval Z-axis raw data
   */
 int16_t LSM6DSM::readRawGyroX(void)
 {
@@ -704,7 +704,7 @@ float LSM6DSM::readTempC(void)
   */
 float LSM6DSM::readTempF(void)
 {
-	float data = readRawTemp() * 45 / 6400 + 77;
+	float data = (float)readRawTemp() * 45 / 6400 + 77;
 
 	return data;
 }

--- a/libraries/00_LIBS/src/lsm6dsm.cpp
+++ b/libraries/00_LIBS/src/lsm6dsm.cpp
@@ -704,9 +704,7 @@ float LSM6DSM::readTempC(void)
   */
 float LSM6DSM::readTempF(void)
 {
-	float data = (float)readRawTemp() / 256;	// Divide by 16 to scale
-	data += 25;                              	// Add 25 degrees to remove offset
-	data = (data * 9) / 5 + 32;
+	float data = readRawTemp() * 45 / 6400 + 77;
 
 	return data;
 }


### PR DESCRIPTION
I decreased the time it takes to retrieve temperature in Fahrenheit. I tested it with Deneyap Card and it was nearly 6 times faster than the old method. Also fixed a typo.